### PR TITLE
🐛 fix compatibility issue with glibc 2.34

### DIFF
--- a/external/catch.hpp
+++ b/external/catch.hpp
@@ -6540,7 +6540,7 @@ namespace Catch {
         static bool isSet;
         static struct sigaction oldSigActions [sizeof(signalDefs)/sizeof(SignalDefs)];
         static stack_t oldSigStack;
-        static char altStackMem[SIGSTKSZ];
+        static char altStackMem[_SC_SIGSTKSZ];
 
         static void handleSignal( int sig ) {
             std::string name = "<unknown signal>";
@@ -6560,7 +6560,7 @@ namespace Catch {
             isSet = true;
             stack_t sigStack;
             sigStack.ss_sp = altStackMem;
-            sigStack.ss_size = SIGSTKSZ;
+            sigStack.ss_size = _SC_SIGSTKSZ;
             sigStack.ss_flags = 0;
             sigaltstack(&sigStack, &oldSigStack);
             struct sigaction sa = { 0 };
@@ -6591,7 +6591,7 @@ namespace Catch {
     bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
     stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+    char FatalConditionHandler::altStackMem[_SC_SIGSTKSZ] = {};
 
 } // namespace Catch
 


### PR DESCRIPTION
starting from v2.34, glibc no longer has MINSIGSTKSZ and SIGSTKSZ as constant on Linux. Instead, a new constant is available to replace them with _SZ_MINSIGSTKSZ and _SZ_SIGSTKSZ, respectively.

**Describe the PR**
A clear and concise description of the PR.

**Related Issues/PRs**
A clear and concise description of what you expected to happen.

**Additional context**
Add any other context about the problem here.
